### PR TITLE
Expose CVE-2025-49758 vulnerability status as MSSQL_Server property

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 # MSSQLHound Release Notes
 
-## Version 2.0
+## Version 2.0.1 (May 5, 2026)
+- Add CVE-2025-49758 to MSSQL_Server node properties
+
+## Version 2.0 (April 23, 2026)
 - Initial Go release
 
 ## Version 1.1 (December 22, 2025)

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -2392,6 +2392,26 @@ func (c *Collector) createServerNode(info *types.ServerInfo) *bloodhound.Node {
 		props["extendedProtection"] = info.ExtendedProtection
 	}
 
+	// CVE-2025-49758: ChangePassword privilege escalation. Vulnerability is determined
+	// by the SQL Server engine version, so it lives on the server node (not per-database).
+	// When the version cannot be parsed, CheckCVE202549758 returns nil and we default
+	// IsVulnerable to false to avoid false positives, matching IsVulnerableToCVE202549758.
+	cveResult := CheckCVE202549758(info.VersionNumber, info.Version)
+	if cveResult != nil {
+		props["isVulnerableToCVE_2025_49758"] = cveResult.IsVulnerable
+		if cveResult.UpdateName != "" {
+			props["cve_2025_49758_updateName"] = cveResult.UpdateName
+		}
+		if cveResult.KB != "" {
+			props["cve_2025_49758_patchKB"] = cveResult.KB
+		}
+		if cveResult.RequiredVersion != "" {
+			props["cve_2025_49758_requiredVersion"] = cveResult.RequiredVersion
+		}
+	} else {
+		props["isVulnerableToCVE_2025_49758"] = false
+	}
+
 	// Add SPNs
 	if len(info.SPNs) > 0 {
 		props["servicePrincipalNames"] = info.SPNs

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -2400,16 +2400,16 @@ func (c *Collector) createServerNode(info *types.ServerInfo) *bloodhound.Node {
 	if cveResult != nil {
 		props["isVulnerableToCVE_2025_49758"] = cveResult.IsVulnerable
 		if cveResult.UpdateName != "" {
-			props["cve_2025_49758_updateName"] = cveResult.UpdateName
+			props["CVE-2025-49758_updateName"] = cveResult.UpdateName
 		}
 		if cveResult.KB != "" {
-			props["cve_2025_49758_patchKB"] = cveResult.KB
+			props["CVE-2025-49758_patchKB"] = cveResult.KB
 		}
 		if cveResult.RequiredVersion != "" {
-			props["cve_2025_49758_requiredVersion"] = cveResult.RequiredVersion
+			props["CVE-2025-49758_requiredVersion"] = cveResult.RequiredVersion
 		}
 	} else {
-		props["isVulnerableToCVE_2025_49758"] = false
+		props["isVulnerableToCVE-2025-49758"] = false
 	}
 
 	// Add SPNs


### PR DESCRIPTION
The CVE check is driven by the SQL Server engine version, so it belongs on the server node rather than per-database. Adds isVulnerableToCVE_2025_49758 plus updateName, patchKB, and requiredVersion when the version maps to a known servicing branch.