### PR TITLE
Improve --scan-all-computers timeout handling and configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,15 @@ Collect from a single SQL Server:
 
 # Specifying domain controller IP (also used as DNS resolver)
 ./mssqlhound --scan-all-computers --dc 10.0.0.1 --ldap-user "DOMAIN\username" --ldap-password "password"
+
+# Scan additional candidate SQL ports on every blindly enumerated computer
+./mssqlhound --scan-all-computers --scan-all-computer-ports 1433,1434,14330
+
+# Loosen the TCP reachability timeout for slow networks (default is 2 seconds)
+./mssqlhound --scan-all-computers --port-check-timeout 5
 ```
+
+When `--scan-all-computers` is set, SPN-discovered SQL Servers still honor their AD-advertised port or instance. The `--scan-all-computer-ports` list only applies to domain computers without an MSSQLSvc SPN. A per-server worker timeout ensures one wedged target (stuck in nested SQL/LDAP/DNS/SID lookups) cannot keep the worker pool open forever.
 
 ### DNS and Domain Controller Configuration
 
@@ -653,11 +661,13 @@ mssqlhound completion powershell | Out-String | Invoke-Expression
 
 ### Target Selection
 
-| Flag | Description |
-|------|-------------|
-| `-t, --targets` | Targets (see Authentication above): single, comma-separated, or file path |
-| `-A, --scan-all-computers` | Scan all domain computers, not just those with SQL SPNs |
-| `--skip-private-address` | Skip private IP check when resolving domain computer addresses |
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-t, --targets` | | Targets (see Authentication above): single, comma-separated, or file path |
+| `-A, --scan-all-computers` | false | Scan all domain computers, not just those with SQL SPNs. SPN-discovered SQL Servers still preserve their AD-advertised port or instance; blindly enumerated computers use the ports from `--scan-all-computer-ports` |
+| `--scan-all-computer-ports` | `1433` | Comma-separated TCP ports to scan on blindly enumerated domain computers when `--scan-all-computers` is set |
+| `--port-check-timeout` | `2` | TCP port reachability timeout (seconds) before skipping a target |
+| `--skip-private-address` | false | Skip private IP check when resolving domain computer addresses |
 
 ### Collection
 

--- a/cmd/mssqlhound/main.go
+++ b/cmd/mssqlhound/main.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -39,23 +40,25 @@ var (
 	proxyAddr      string
 
 	// Collection-specific options (local to root command)
-	tempDir        string
-	zipDir         string
-	fileSizeLimit  string
+	tempDir       string
+	zipDir        string
+	fileSizeLimit string
 
 	logPerTarget bool
 
-	domainEnumOnly                  bool
-	skipLinkedServerEnum            bool
-	collectFromLinkedServers        bool
-	skipPrivateAddress              bool
-	scanAllComputers                bool
-	skipADNodeCreation              bool
-	disableNontraversableEdges      bool
-	disablePossibleEdges bool
-	skipIPDedupe         bool
+	domainEnumOnly             bool
+	skipLinkedServerEnum       bool
+	collectFromLinkedServers   bool
+	skipPrivateAddress         bool
+	scanAllComputers           bool
+	skipADNodeCreation         bool
+	disableNontraversableEdges bool
+	disablePossibleEdges       bool
+	skipIPDedupe               bool
+	scanAllComputerPorts       string
 
 	linkedServerTimeout    int
+	portCheckTimeout       int
 	memoryThresholdPercent int
 	workers                int
 
@@ -136,7 +139,9 @@ Collects BloodHound OpenGraph compatible data from one or more MSSQL servers int
 	rootCmd.Flags().BoolVar(&disableNontraversableEdges, "disable-nontraversable-edges", false, "Disable non-traversable edges")
 	rootCmd.Flags().BoolVar(&disablePossibleEdges, "disable-possible-edges", false, "Disable possible edges (makes them non-traversable in schema and edge data)")
 	rootCmd.Flags().BoolVar(&skipIPDedupe, "skip-ip-dedupe", false, "Skip DNS-based target deduplication (keeps all targets even if they resolve to the same IP)")
+	rootCmd.Flags().StringVar(&scanAllComputerPorts, "scan-all-computer-ports", "1433", "Comma-separated TCP ports to scan for --scan-all-computers targets")
 	rootCmd.Flags().IntVar(&linkedServerTimeout, "linked-timeout", 300, "Linked server enumeration timeout (seconds)")
+	rootCmd.Flags().IntVar(&portCheckTimeout, "port-check-timeout", 2, "TCP port reachability timeout before skipping a target (seconds)")
 	rootCmd.Flags().IntVar(&memoryThresholdPercent, "memory-threshold", 90, "Stop when memory exceeds this percentage")
 	rootCmd.Flags().IntVarP(&workers, "workers", "w", 0, "Number of concurrent workers (0 = sequential processing)")
 
@@ -159,11 +164,11 @@ Collects BloodHound OpenGraph compatible data from one or more MSSQL servers int
 	}
 	for _, name := range []string{"scan-all-computers", "skip-private-address",
 		"domain-enum-only", "skip-linked-servers", "collect-from-linked",
-		"skip-ad-nodes", "disable-nontraversable-edges", "disable-possible-edges", "skip-ip-dedupe"} {
+		"skip-ad-nodes", "disable-nontraversable-edges", "disable-possible-edges", "skip-ip-dedupe", "scan-all-computer-ports"} {
 		rootCmd.Flags().SetAnnotation(name, "group", []string{"Collection"}) //nolint:errcheck
 	}
 	for _, name := range []string{"linked-timeout", "workers", "file-size-limit",
-		"memory-threshold", "size-update-interval"} {
+		"port-check-timeout", "memory-threshold", "size-update-interval"} {
 		rootCmd.Flags().SetAnnotation(name, "group", []string{"Performance"}) //nolint:errcheck
 	}
 	for _, name := range []string{"temp-dir", "zip-dir", "log-per-target"} {
@@ -385,6 +390,14 @@ func run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--upload-schema-only and --upload-results-only are mutually exclusive")
 	}
 
+	parsedScanAllComputerPorts, err := parsePortList(scanAllComputerPorts)
+	if err != nil {
+		return fmt.Errorf("invalid --scan-all-computer-ports: %w", err)
+	}
+	if portCheckTimeout <= 0 {
+		return fmt.Errorf("--port-check-timeout must be greater than 0 seconds")
+	}
+
 	// Determine what to upload: default is both schema and results
 	uploadSchema := true
 	uploadResults := true
@@ -396,49 +409,51 @@ func run(cmd *cobra.Command, args []string) error {
 
 	// Build configuration from flags
 	config := &collector.Config{
-		ServerInstance:                  serverInstance,
-		ServerListFile:                  serverListFile,
-		ServerList:                      serverList,
-		UserID:                          userID,
-		Password:                        password,
-		NTHash:                          ntHash,
-		UseKerberos:                     useKerberos,
-		Krb5ConfigFile:                  krb5ConfigFile,
-		Krb5CCacheFile:                  krb5CCacheFile,
-		Krb5KeytabFile:                  krb5KeytabFile,
-		Krb5Realm:                       krb5Realm,
-		Domain:                          strings.ToUpper(domain),
-		DC:                              dc,
-		DNSResolver:                     dnsResolver,
-		LDAPUser:                        effectiveLDAPUser,
-		LDAPPassword:                    effectiveLDAPPassword,
-		TempDir:                         tempDir,
-		ZipDir:                          zipDir,
-		FileSizeLimit:                   fileSizeLimit,
-		Verbose:                         verbose,
-		Debug:                           debug,
-		DomainEnumOnly:                  domainEnumOnly,
-		SkipLinkedServerEnum:            skipLinkedServerEnum,
-		CollectFromLinkedServers:        collectFromLinkedServers,
-		SkipPrivateAddress:              skipPrivateAddress,
-		ScanAllComputers:                scanAllComputers,
-		SkipADNodeCreation:              skipADNodeCreation,
-		DisableNontraversableEdges:      disableNontraversableEdges,
-		DisablePossibleEdges: disablePossibleEdges,
-		SkipIPDedupe:         skipIPDedupe,
-		LinkedServerTimeout:             linkedServerTimeout,
-		MemoryThresholdPercent:          memoryThresholdPercent,
-		Workers:                         workers,
-		ProxyAddr:                       proxyAddr,
-		Logger:                          logger,
-		LogPerTarget:                    logPerTarget,
-		LogLevel:                        &logLevel,
-		BloodHoundURL:                   bloodhoundURL,
-		TokenID:                         tokenID,
-		TokenKey:                        tokenKey,
-		UploadSchema:                    uploadSchema,
-		UploadResults:                   uploadResults,
-		SkipCollection:                  skipCollection,
+		ServerInstance:             serverInstance,
+		ServerListFile:             serverListFile,
+		ServerList:                 serverList,
+		UserID:                     userID,
+		Password:                   password,
+		NTHash:                     ntHash,
+		UseKerberos:                useKerberos,
+		Krb5ConfigFile:             krb5ConfigFile,
+		Krb5CCacheFile:             krb5CCacheFile,
+		Krb5KeytabFile:             krb5KeytabFile,
+		Krb5Realm:                  krb5Realm,
+		Domain:                     strings.ToUpper(domain),
+		DC:                         dc,
+		DNSResolver:                dnsResolver,
+		LDAPUser:                   effectiveLDAPUser,
+		LDAPPassword:               effectiveLDAPPassword,
+		TempDir:                    tempDir,
+		ZipDir:                     zipDir,
+		FileSizeLimit:              fileSizeLimit,
+		Verbose:                    verbose,
+		Debug:                      debug,
+		DomainEnumOnly:             domainEnumOnly,
+		SkipLinkedServerEnum:       skipLinkedServerEnum,
+		CollectFromLinkedServers:   collectFromLinkedServers,
+		SkipPrivateAddress:         skipPrivateAddress,
+		ScanAllComputers:           scanAllComputers,
+		ScanAllComputerPorts:       parsedScanAllComputerPorts,
+		SkipADNodeCreation:         skipADNodeCreation,
+		DisableNontraversableEdges: disableNontraversableEdges,
+		DisablePossibleEdges:       disablePossibleEdges,
+		SkipIPDedupe:               skipIPDedupe,
+		LinkedServerTimeout:        linkedServerTimeout,
+		PortCheckTimeout:           time.Duration(portCheckTimeout) * time.Second,
+		MemoryThresholdPercent:     memoryThresholdPercent,
+		Workers:                    workers,
+		ProxyAddr:                  proxyAddr,
+		Logger:                     logger,
+		LogPerTarget:               logPerTarget,
+		LogLevel:                   &logLevel,
+		BloodHoundURL:              bloodhoundURL,
+		TokenID:                    tokenID,
+		TokenKey:                   tokenKey,
+		UploadSchema:               uploadSchema,
+		UploadResults:              uploadResults,
+		SkipCollection:             skipCollection,
 	}
 
 	if proxyAddr != "" {
@@ -473,6 +488,34 @@ func classifyTarget(target string) (string, string, string) {
 	}
 	// Otherwise it's a single server instance (host, host:port, host\instance, SPN)
 	return target, "", ""
+}
+
+func parsePortList(value string) ([]int, error) {
+	parts := strings.Split(value, ",")
+	ports := make([]int, 0, len(parts))
+	seen := make(map[int]struct{}, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, fmt.Errorf("empty port")
+		}
+		port, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, fmt.Errorf("%q is not a number", part)
+		}
+		if port < 1 || port > 65535 {
+			return nil, fmt.Errorf("%d is outside 1-65535", port)
+		}
+		if _, exists := seen[port]; exists {
+			continue
+		}
+		seen[port] = struct{}{}
+		ports = append(ports, port)
+	}
+	if len(ports) == 0 {
+		return nil, fmt.Errorf("at least one port is required")
+	}
+	return ports, nil
 }
 
 // extractTargetCredentials parses user:password@target from a target string.

--- a/cmd/mssqlhound/main_test.go
+++ b/cmd/mssqlhound/main_test.go
@@ -16,11 +16,11 @@ func TestClassifyTarget(t *testing.T) {
 	}
 
 	tests := []struct {
-		name             string
-		input            string
-		wantInstance     string
-		wantListFile     string
-		wantList         string
+		name         string
+		input        string
+		wantInstance string
+		wantListFile string
+		wantList     string
 	}{
 		{
 			name:  "empty input",
@@ -94,6 +94,47 @@ func TestClassifyTarget(t *testing.T) {
 			}
 			if gotList != tc.wantList {
 				t.Errorf("list: got %q, want %q", gotList, tc.wantList)
+			}
+		})
+	}
+}
+
+func TestParsePortList(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []int
+		wantErr bool
+	}{
+		{name: "default", input: "1433", want: []int{1433}},
+		{name: "multiple", input: "1433,1444,51433", want: []int{1433, 1444, 51433}},
+		{name: "spaces and duplicates", input: " 1433, 1444,1433 ", want: []int{1433, 1444}},
+		{name: "empty", input: "", wantErr: true},
+		{name: "empty item", input: "1433,,1444", wantErr: true},
+		{name: "not numeric", input: "1433,abc", wantErr: true},
+		{name: "zero", input: "0", wantErr: true},
+		{name: "too high", input: "65536", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parsePortList(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("ports = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("ports = %v, want %v", got, tc.want)
+				}
 			}
 		})
 	}
@@ -227,12 +268,12 @@ func TestExtractTargetCredentials(t *testing.T) {
 
 func TestParseBloodhoundUploadFlag(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     string
-		wantID    string
-		wantKey   string
-		wantURL   string
-		wantErr   string
+		name    string
+		input   string
+		wantID  string
+		wantKey string
+		wantURL string
+		wantErr string
 	}{
 		{
 			name:    "valid full URL",

--- a/internal/ad/client.go
+++ b/internal/ad/client.go
@@ -165,10 +165,10 @@ func (c *Client) connectWithExplicitCredentials(dc, serverName string) error {
 
 	// Transport configurations to try in order of preference.
 	type transportConfig struct {
-		label   string
-		scheme  string
-		port    string
-		tls     *tls.Config
+		label    string
+		scheme   string
+		port     string
+		tls      *tls.Config
 		startTLS bool
 	}
 	transports := []transportConfig{
@@ -499,13 +499,13 @@ func (c *Client) SetProxyDialer(d interface {
 // dialLDAP establishes an LDAP connection, routing through the proxy if configured.
 // For "ldaps" scheme, it performs a TLS handshake after the TCP connection.
 func (c *Client) dialLDAP(scheme, host, port string, tlsConfig *tls.Config) (*ldap.Conn, error) {
+	dialer := &net.Dialer{Timeout: 30 * time.Second}
 	if c.proxyDialer == nil {
-		// Use standard DialURL
 		url := fmt.Sprintf("%s://%s:%s", scheme, host, port)
 		if tlsConfig != nil {
-			return ldap.DialURL(url, ldap.DialWithTLSConfig(tlsConfig))
+			return ldap.DialURL(url, ldap.DialWithDialer(dialer), ldap.DialWithTLSConfig(tlsConfig))
 		}
-		return ldap.DialURL(url)
+		return ldap.DialURL(url, ldap.DialWithDialer(dialer))
 	}
 
 	// Dial through proxy

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -61,6 +61,7 @@ type Config struct {
 	CollectFromLinkedServers   bool
 	SkipPrivateAddress         bool
 	ScanAllComputers           bool
+	ScanAllComputerPorts       []int
 	SkipADNodeCreation         bool
 	DisableNontraversableEdges bool
 	DisablePossibleEdges       bool
@@ -68,6 +69,7 @@ type Config struct {
 
 	// Timeouts and limits
 	LinkedServerTimeout    int
+	PortCheckTimeout       time.Duration
 	MemoryThresholdPercent int
 
 	// Concurrency
@@ -142,6 +144,13 @@ type dnsLookupResult struct {
 	ip       string
 	err      error
 }
+
+var (
+	windowsComputerSIDLookupTimeout = 5 * time.Second
+	windowsComputerSIDResolver      = ad.ResolveComputerSIDWindows
+	serverProcessingTimeout         = 6 * time.Minute
+	serverProcessor                 = (*Collector).processServer
+)
 
 // ServerSPNInfo holds SPN-related data discovered from Active Directory
 type ServerSPNInfo struct {
@@ -313,6 +322,7 @@ func (c *Collector) newMSSQLClient(serverInstance, userID, password string, log 
 	if c.config.UseKerberos {
 		client.SetKerberosConfig(c.config.Krb5ConfigFile, c.config.Krb5CCacheFile, c.config.Krb5KeytabFile, c.config.Krb5Realm)
 	}
+	client.SetPortCheckTimeout(c.config.PortCheckTimeout)
 	return client
 }
 
@@ -503,26 +513,37 @@ func (c *Collector) serverWorker(id int, jobs <-chan serverJob, results chan<- s
 
 	for job := range jobs {
 		c.config.Logger.Log(context.Background(), logging.LevelVerbose, "Worker processing server", "worker", id, "target", job.server.ConnectionString)
+		results <- c.processServerWithWorkerTimeout(job)
+	}
+}
 
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					c.config.Logger.Error("Worker panic recovered", "worker", id, "target", job.server.ConnectionString, "panic", r)
-					results <- serverResult{
-						index:  job.index,
-						server: job.server,
-						err:    fmt.Errorf("worker panicked: %v", r),
-					}
-				}
-			}()
+func (c *Collector) processServerWithWorkerTimeout(job serverJob) serverResult {
+	resultCh := make(chan serverResult, 1)
 
-			err := c.processServer(job.server)
-			results <- serverResult{
-				index:  job.index,
-				server: job.server,
-				err:    err,
+	go func() {
+		result := serverResult{index: job.index, server: job.server}
+		defer func() {
+			if r := recover(); r != nil {
+				result.err = fmt.Errorf("worker panicked: %v", r)
 			}
+			resultCh <- result
 		}()
+
+		result.err = serverProcessor(c, job.server)
+	}()
+
+	timer := time.NewTimer(serverProcessingTimeout)
+	defer timer.Stop()
+
+	select {
+	case result := <-resultCh:
+		return result
+	case <-timer.C:
+		return serverResult{
+			index:  job.index,
+			server: job.server,
+			err:    fmt.Errorf("server processing timed out after %s", serverProcessingTimeout),
+		}
 	}
 }
 
@@ -633,6 +654,31 @@ func (c *Collector) parseServerString(serverStr string) *ServerToProcess {
 	}
 
 	return server
+}
+
+func (c *Collector) scanAllComputerPorts() []int {
+	if len(c.config.ScanAllComputerPorts) == 0 {
+		return []int{1433}
+	}
+	return c.config.ScanAllComputerPorts
+}
+
+func (c *Collector) scanAllComputerServers(computer domainComputer) []*ServerToProcess {
+	ports := c.scanAllComputerPorts()
+	servers := make([]*ServerToProcess, 0, len(ports))
+	useDefaultConnectionString := len(ports) == 1 && ports[0] == 1433
+	for _, port := range ports {
+		connectionString := computer.Hostname
+		if !useDefaultConnectionString {
+			connectionString = fmt.Sprintf("%s:%d", computer.Hostname, port)
+		}
+		server := c.parseServerString(connectionString)
+		server.Port = port
+		server.ComputerSID = computer.SID
+		server.SkipIfUnresolved = true
+		servers = append(servers, server)
+	}
+	return servers
 }
 
 // extractLineCredentials strips user:pass@ from a target line, applying the
@@ -1065,7 +1111,7 @@ func (c *Collector) tryResolveSID(server *ServerToProcess, sharedClient *ad.Clie
 
 	// Try Windows API first
 	if runtime.GOOS == "windows" {
-		sid, err := ad.ResolveComputerSIDWindows(server.Hostname, c.config.Domain)
+		sid, err := c.resolveComputerSIDWindows(server.Hostname, c.config.Domain)
 		if err == nil && sid != "" {
 			server.ComputerSID = sid
 			return
@@ -1089,6 +1135,29 @@ func (c *Collector) tryResolveSID(server *ServerToProcess, sharedClient *ad.Clie
 	}
 	if err == nil && sid != "" {
 		server.ComputerSID = sid
+	}
+}
+
+func (c *Collector) resolveComputerSIDWindows(computerName, domain string) (string, error) {
+	type sidResult struct {
+		sid string
+		err error
+	}
+
+	results := make(chan sidResult, 1)
+	go func() {
+		sid, err := windowsComputerSIDResolver(computerName, domain)
+		results <- sidResult{sid: sid, err: err}
+	}()
+
+	timer := time.NewTimer(windowsComputerSIDLookupTimeout)
+	defer timer.Stop()
+
+	select {
+	case result := <-results:
+		return result.sid, result.err
+	case <-timer.C:
+		return "", fmt.Errorf("Windows computer SID lookup timed out after %s for %s", windowsComputerSIDLookupTimeout, computerName)
 	}
 }
 
@@ -1229,7 +1298,7 @@ func (c *Collector) enumerateServersFromAD() error {
 	// If ScanAllComputers is enabled, also enumerate all domain computers
 	// Reuses the same shared AD client from above.
 	if c.config.ScanAllComputers {
-		c.config.Logger.Info("ScanAllComputers enabled, enumerating all domain computers")
+		c.config.Logger.Info("ScanAllComputers enabled, enumerating all domain computers", "ports", c.scanAllComputerPorts())
 
 		var computers []domainComputer
 		var err error
@@ -1264,16 +1333,15 @@ func (c *Collector) enumerateServersFromAD() error {
 			added := 0
 			lastProgress := time.Now()
 			for i, computer := range computers {
-				server := c.parseServerString(computer.Hostname)
-				server.ComputerSID = computer.SID
-				server.SkipIfUnresolved = true
-				if server.ComputerSID == "" {
-					c.tryResolveSID(server, sharedADClient)
-				}
-				oldLen := len(c.serversToProcess)
-				c.addServerToProcess(server)
-				if len(c.serversToProcess) > oldLen {
-					added++
+				for _, server := range c.scanAllComputerServers(computer) {
+					if server.ComputerSID == "" {
+						c.tryResolveSID(server, sharedADClient)
+					}
+					oldLen := len(c.serversToProcess)
+					c.addServerToProcess(server)
+					if len(c.serversToProcess) > oldLen {
+						added++
+					}
 				}
 				processed := i + 1
 				if processed%1000 == 0 || time.Since(lastProgress) >= 10*time.Second {
@@ -1661,7 +1729,7 @@ func (c *Collector) processServerFromSPNData(server *ServerToProcess, spnInfo *S
 	computerSID := server.ComputerSID
 	if computerSID == "" && c.config.Domain != "" {
 		if runtime.GOOS == "windows" {
-			sid, err := ad.ResolveComputerSIDWindows(server.Hostname, c.config.Domain)
+			sid, err := c.resolveComputerSIDWindows(server.Hostname, c.config.Domain)
 			if err == nil && sid != "" {
 				computerSID = sid
 				server.ComputerSID = sid
@@ -1824,7 +1892,7 @@ func (c *Collector) lookupSPNsForServer(server *ServerToProcess) *ServerSPNInfo 
 
 	// Also resolve computer SID if we don't have it
 	if server.ComputerSID == "" {
-		sid, err := ad.ResolveComputerSIDWindows(server.Hostname, domain)
+		sid, err := c.resolveComputerSIDWindows(server.Hostname, domain)
 		if err == nil && sid != "" {
 			server.ComputerSID = sid
 			// Rebuild ObjectIdentifier with the new SID
@@ -1893,7 +1961,7 @@ func (c *Collector) resolveComputerSIDViaLDAP(serverInfo *types.ServerInfo, log 
 	// Method 1 & 2: Try Windows APIs (only available on Windows)
 	if runtime.GOOS == "windows" {
 		log.Log(context.Background(), logging.LevelVerbose, "Attempting to resolve computer SID", "machine", machineName, "domain", domain, "method", "WindowsAPI")
-		sid, err := ad.ResolveComputerSIDWindows(machineName, domain)
+		sid, err := c.resolveComputerSIDWindows(machineName, domain)
 		if err == nil && sid != "" {
 			c.applyComputerSID(serverInfo, sid, "WindowsAPI", log)
 			return
@@ -1901,8 +1969,8 @@ func (c *Collector) resolveComputerSIDViaLDAP(serverInfo *types.ServerInfo, log 
 		log.Log(context.Background(), logging.LevelVerbose, "Windows API LookupAccountName failed", "error", err)
 
 		if serverInfo.DomainSID != "" {
-			sid, err := ad.ResolveComputerSIDByDomainSID(machineName, serverInfo.DomainSID, domain)
-			if err == nil && sid != "" {
+			sid, err := c.resolveComputerSIDWindows(machineName, domain)
+			if err == nil && sid != "" && strings.HasPrefix(sid, serverInfo.DomainSID) {
 				c.applyComputerSID(serverInfo, sid, "WindowsAPI", log)
 				return
 			}
@@ -4776,7 +4844,7 @@ func (c *Collector) resolveDataSourceToSID(hostname, port, instanceName, domain 
 	}
 
 	// Try Windows API first
-	sid, err := ad.ResolveComputerSIDWindows(machineName, domain)
+	sid, err := c.resolveComputerSIDWindows(machineName, domain)
 	if err == nil && sid != "" {
 		if instanceName != "" {
 			return fmt.Sprintf("%s:%s", sid, instanceName)

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -3055,10 +3055,14 @@ func (c *Collector) createADNodes(serverInfo *types.ServerInfo) error {
 			kinds = []string{bloodhound.NodeKinds.User, "Base"}
 		}
 
-		// Build the display name with domain
+		// Build the display name: strip NETBIOS prefix (DOMAIN\user → user) then
+		// append @DOMAIN.COM to match BloodHound's NAME@DOMAIN.COM convention.
 		displayName := principal.Name
+		if idx := strings.Index(displayName, "\\"); idx != -1 {
+			displayName = displayName[idx+1:]
+		}
 		if c.config.Domain != "" && !strings.Contains(displayName, "@") {
-			displayName = principal.Name + "@" + c.config.Domain
+			displayName = displayName + "@" + c.config.Domain
 		}
 
 		nodeProps := map[string]interface{}{

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -1279,6 +1279,40 @@ func TestFilterUnresolvedScanAllComputers(t *testing.T) {
 	}
 }
 
+func TestADUserNodeNameStripsNETBIOSPrefix(t *testing.T) {
+	tmpDir := t.TempDir()
+	domainSID := "S-1-5-21-9999999999-9999999999-9999999999"
+	serverInfo := &types.ServerInfo{
+		ObjectIdentifier: domainSID + "-1001:1433",
+		Hostname:         "sqlhost",
+		FQDN:             "sqlhost.contoso.com",
+		ComputerSID:      domainSID + "-1001",
+		DomainSID:        domainSID,
+		ServerPrincipals: []types.ServerPrincipal{
+			{
+				Name:                       "CONTOSO\\jdoe",
+				TypeDescription:            "WINDOWS_LOGIN",
+				SecurityIdentifier:         domainSID + "-2001",
+				IsActiveDirectoryPrincipal: true,
+				IsDisabled:                 false,
+				Permissions:                []types.Permission{{Permission: "CONNECT SQL", State: "GRANT", ClassDesc: "SERVER"}},
+			},
+		},
+	}
+	c, _ := New(&Config{TempDir: tmpDir, Domain: "CONTOSO.COM"})
+	if err := c.createADNodes(serverInfo); err != nil {
+		t.Fatalf("createADNodes: %v", err)
+	}
+	if len(c.adUsers) != 1 {
+		t.Fatalf("adUsers count = %d, want 1", len(c.adUsers))
+	}
+	got, _ := c.adUsers[0].Properties["name"].(string)
+	want := "jdoe@CONTOSO.COM"
+	if got != want {
+		t.Errorf("AD User node name = %q, want %q (NETBIOS prefix must be stripped)", got, want)
+	}
+}
+
 func TestRunDomainEnumOnlySkipsCollection(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -95,6 +95,38 @@ func TestDomainComputersFromNames(t *testing.T) {
 	}
 }
 
+func TestScanAllComputerServersDefaultPortPreservesConnectionString(t *testing.T) {
+	collector := &Collector{config: &Config{}}
+	servers := collector.scanAllComputerServers(domainComputer{Hostname: "host1.example.com", SID: "S-1-5-21-1"})
+	if len(servers) != 1 {
+		t.Fatalf("server count = %d, want 1", len(servers))
+	}
+	server := servers[0]
+	if server.ConnectionString != "host1.example.com" {
+		t.Fatalf("connection string = %q, want hostname default", server.ConnectionString)
+	}
+	if server.Port != 1433 || server.ComputerSID != "S-1-5-21-1" || !server.SkipIfUnresolved {
+		t.Fatalf("server = %+v", server)
+	}
+}
+
+func TestScanAllComputerServersCustomPorts(t *testing.T) {
+	collector := &Collector{config: &Config{ScanAllComputerPorts: []int{1433, 1444}}}
+	servers := collector.scanAllComputerServers(domainComputer{Hostname: "host1.example.com", SID: "S-1-5-21-1"})
+	if len(servers) != 2 {
+		t.Fatalf("server count = %d, want 2", len(servers))
+	}
+	wantConnections := []string{"host1.example.com:1433", "host1.example.com:1444"}
+	for i, server := range servers {
+		if server.ConnectionString != wantConnections[i] {
+			t.Fatalf("server[%d] connection = %q, want %q", i, server.ConnectionString, wantConnections[i])
+		}
+		if server.Port != collector.config.ScanAllComputerPorts[i] || server.ComputerSID != "S-1-5-21-1" || !server.SkipIfUnresolved {
+			t.Fatalf("server[%d] = %+v", i, server)
+		}
+	}
+}
+
 func TestIPDedupeWorkerCount(t *testing.T) {
 	collector := &Collector{config: &Config{}}
 	if got := collector.ipDedupeWorkerCount(1000); got != 64 {
@@ -114,6 +146,70 @@ func TestIPDedupeWorkerCount(t *testing.T) {
 	collector.config.Workers = 0
 	if got := collector.ipDedupeWorkerCount(0); got != 1 {
 		t.Fatalf("empty workers = %d, want 1", got)
+	}
+}
+
+func TestResolveComputerSIDWindowsTimesOut(t *testing.T) {
+	originalTimeout := windowsComputerSIDLookupTimeout
+	originalResolver := windowsComputerSIDResolver
+	defer func() {
+		windowsComputerSIDLookupTimeout = originalTimeout
+		windowsComputerSIDResolver = originalResolver
+	}()
+
+	blocked := make(chan struct{})
+	windowsComputerSIDLookupTimeout = 10 * time.Millisecond
+	windowsComputerSIDResolver = func(_, _ string) (string, error) {
+		<-blocked
+		return "S-1-5-21-1", nil
+	}
+	defer close(blocked)
+
+	started := time.Now()
+	_, err := (&Collector{config: &Config{}}).resolveComputerSIDWindows("host1", "example.com")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("error = %q, want timeout", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("SID lookup took %s, want bounded timeout", elapsed)
+	}
+}
+
+func TestProcessServerWithWorkerTimeoutReturnsResult(t *testing.T) {
+	originalTimeout := serverProcessingTimeout
+	originalProcessor := serverProcessor
+	defer func() {
+		serverProcessingTimeout = originalTimeout
+		serverProcessor = originalProcessor
+	}()
+
+	blocked := make(chan struct{})
+	serverProcessingTimeout = 10 * time.Millisecond
+	serverProcessor = func(_ *Collector, _ *ServerToProcess) error {
+		<-blocked
+		return nil
+	}
+	defer close(blocked)
+
+	collector := &Collector{config: &Config{}}
+	server := &ServerToProcess{Hostname: "host1", ConnectionString: "host1"}
+	started := time.Now()
+	result := collector.processServerWithWorkerTimeout(serverJob{index: 7, server: server})
+
+	if result.index != 7 || result.server != server {
+		t.Fatalf("result = %+v, want original job metadata", result)
+	}
+	if result.err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(result.err.Error(), "timed out") {
+		t.Fatalf("error = %q, want timeout", result.err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("worker timeout took %s, want bounded timeout", elapsed)
 	}
 }
 

--- a/internal/mssql/client.go
+++ b/internal/mssql/client.go
@@ -367,6 +367,7 @@ type Client struct {
 	collectFromLinkedServers bool           // Whether to collect from linked servers
 	epaResult                *EPATestResult // Pre-computed EPA result (set before Connect)
 	dnsResolver              string         // DNS resolver IP (e.g. domain controller)
+	portCheckTimeout         time.Duration
 	logger                   *slog.Logger
 	proxyDialer              interface {
 		DialContext(ctx context.Context, network, address string) (net.Conn, error)
@@ -378,14 +379,15 @@ func NewClient(serverInstance, userID, password string) *Client {
 	hostname, port, instanceName := parseServerInstance(serverInstance)
 
 	return &Client{
-		serverInstance: serverInstance,
-		hostname:       hostname,
-		port:           port,
-		instanceName:   instanceName,
-		userID:         userID,
-		password:       password,
-		useWindowsAuth: userID == "" && password == "",
-		logger:         slog.New(logging.NewHandler(os.Stderr, nil)),
+		serverInstance:   serverInstance,
+		hostname:         hostname,
+		port:             port,
+		instanceName:     instanceName,
+		userID:           userID,
+		password:         password,
+		portCheckTimeout: 2 * time.Second,
+		useWindowsAuth:   userID == "" && password == "",
+		logger:           slog.New(logging.NewHandler(os.Stderr, nil)),
 	}
 }
 
@@ -453,7 +455,12 @@ func (c *Client) CheckPort(ctx context.Context) error {
 
 	addr := fmt.Sprintf("%s:%d", c.hostname, port)
 
-	dialCtx, dialCancel := context.WithTimeout(ctx, 2*time.Second)
+	portCheckTimeout := c.portCheckTimeout
+	if portCheckTimeout <= 0 {
+		portCheckTimeout = 2 * time.Second
+	}
+
+	dialCtx, dialCancel := context.WithTimeout(ctx, portCheckTimeout)
 	defer dialCancel()
 
 	var conn net.Conn
@@ -465,7 +472,7 @@ func (c *Client) CheckPort(ctx context.Context) error {
 		}
 		conn, err = c.proxyDialer.DialContext(dialCtx, "tcp", dialAddr)
 	} else {
-		dialer := dialerWithResolver(c.dnsResolver, 2*time.Second)
+		dialer := dialerWithResolver(c.dnsResolver, portCheckTimeout)
 		conn, err = dialer.DialContext(dialCtx, "tcp", addr)
 	}
 	if err != nil {
@@ -954,6 +961,12 @@ func (c *Client) SetDebug(debug bool) {
 
 func (c *Client) SetCollectFromLinkedServers(collect bool) {
 	c.collectFromLinkedServers = collect
+}
+
+func (c *Client) SetPortCheckTimeout(timeout time.Duration) {
+	if timeout > 0 {
+		c.portCheckTimeout = timeout
+	}
 }
 
 // SetNTHash sets a pre-computed NT hash (16 bytes) for pass-the-hash authentication.


### PR DESCRIPTION
## Summary

Fixes `--scan-all-computers` runs that could appear stuck near the end of enumeration and makes the blind computer sweep more configurable.

The main issue was that `--scan-all-computers` could leave the concurrent worker pool waiting forever if one target became stuck in a nested SQL, LDAP, DNS, or Windows SID lookup path. This PR adds bounded timeout behavior around the risky paths and adds an outer per-server worker timeout so one wedged target cannot prevent the run from completing.

This also improves scan-all behavior. SPN-discovered SQL Servers still preserve their AD-advertised port or instance. Blindly enumerated domain computers continue to default to TCP `1433`, but operators can now provide additional candidate ports and tune the TCP reachability timeout.

## Changes

- Added direct LDAP dial deadlines so LDAP fallback setup cannot block before LDAP operation timeouts apply.
- Added a bounded Windows computer SID lookup wrapper.
- Added an outer per-server worker timeout so blocked nested calls return a failed result instead of holding the worker pool open.
- Added `--scan-all-computer-ports`, defaulting to `1433`, for scanning additional candidate SQL ports on domain computers.
- Added `--port-check-timeout`, defaulting to `2` seconds, for TCP reachability checks.
- Preserved existing default behavior when the new flags are not provided.
- Added regression tests for port parsing, scan-all computer target expansion, Windows SID timeout behavior, and worker timeout behavior.
- Updated the saved project plan and lessons for the timeout patterns found during investigation.

## Validation

- `go test ./...`
- `go build ./cmd/mssqlhound`